### PR TITLE
Driver's Seat v2.0.24 - Remove invalid gradle that conflicts with capacitor build

### DIFF
--- a/intercom-plugin/src/android/build-extras-intercom.gradle
+++ b/intercom-plugin/src/android/build-extras-intercom.gradle
@@ -4,8 +4,11 @@ import java.util.regex.Matcher
 // INSTALL_FAILED_CONFLICTING_PROVIDER error when installing the app.
 //
 // @link https://issues.apache.org/jira/browse/CB-10014
-def manifest = new XmlSlurper().parse(file("src/main/AndroidManifest.xml"))
-android.defaultConfig.applicationId manifest.@package.text()
+
+//DRIVER'S SEAT:  Removing this as it conflicts with the build by
+//                setting ApplicationId to literal "manifest.@package.text()"
+//def manifest = new XmlSlurper().parse(file("src/main/AndroidManifest.xml"))
+//android.defaultConfig.applicationId manifest.@package.text()
 
 // some libraries depend on higher versions of our dependencies than we support
 // we keep track of these dependencies here and override the version to a safe one


### PR DESCRIPTION
- no reason to rename the package in the build, it causes capacitor build problems.